### PR TITLE
Add generic types + hide implementation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    container: google/dart:2
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: pub get
+      - name: Run tests
+        run: pub run test
+      - name: Run analyzer
+        run: dartanalyzer .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
+# Changelog
+
+## 2.0.0
+
+- Futures returned by `add` are typed.
+- **Breaking**: Some fields related to the internal implementation are private.
+- **Breaking**: `delay` cannot be modified after instanciation.
+- **Breaking**: An exception will be thrown if `add` is called after the queue has been cancelled.
+
 ## 1.0.1+2
+
 - Improving the readme
 
 ## 1.0.1+1
+
 - Improving the package description
 
 ## 1.0.1
+
 - Removing some console output
 
 ## 1.0.0
+
 - Initial version

--- a/lib/queue.dart
+++ b/lib/queue.dart
@@ -1,3 +1,3 @@
 library dart_queue;
 
-export 'src/dart_queue_base.dart';
+export 'src/dart_queue_base.dart' hide unawaited;

--- a/lib/src/dart_queue_base.dart
+++ b/lib/src/dart_queue_base.dart
@@ -18,24 +18,39 @@ class _QueuedFuture<T> {
   }
 }
 
+/// Queue to execute Futures in order.
+/// It awaits each future before executing the next one.
 class Queue {
   final List<_QueuedFuture> _nextCycle = [];
+
+  /// A delay to await between each future.
   final Duration delay;
+
   bool _isProcessing = false;
   bool _isCancelled = false;
 
   bool get isCancelled => _isCancelled;
 
+  /// Cancels the queue.
+  ///
+  /// Subsquent calls to [add] will throw.
   void cancel() {
     _isCancelled = true;
   }
 
+  /// Alias for [cancel].
   void dispose() {
     cancel();
   }
 
   Queue({this.delay});
 
+  /// Adds the future-returning closure to the queue.
+  ///
+  /// It will be executed after futures returned
+  /// by preceding closures have been awaited.
+  ///
+  /// Will throw an exception if the queue has been cancelled.
   Future<T> add<T>(Future<T> Function() closure) {
     if (isCancelled) throw Exception('Queue is cancelled');
     final completer = Completer<T>();

--- a/lib/src/dart_queue_base.dart
+++ b/lib/src/dart_queue_base.dart
@@ -40,11 +40,11 @@ class Queue {
     if (isCancelled) throw Exception('Queue is cancelled');
     final completer = Completer<T>();
     _nextCycle.add(_QueuedFuture<T>(closure, completer));
-    unawaited(process());
+    unawaited(_process());
     return completer.future;
   }
 
-  Future<void> process() async {
+  Future<void> _process() async {
     if (!_isProcessing) {
       _isProcessing = true;
       final currentCycle = List.of(_nextCycle);
@@ -56,7 +56,7 @@ class Queue {
       _isProcessing = false;
       if (!_isCancelled && _nextCycle.isNotEmpty) {
         await Future.microtask(() {}); // yield to prevent stack overflow
-        unawaited(process());
+        unawaited(_process());
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: queue
 description: Queue up futures from multiple sources and await their return anywhere in your code.
-version: 1.0.1+1
+version: 2.0.0
 homepage: https://github.com/rknell/dart_queue
 repository: https://github.com/rknell/dart_queue
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: ">=2.7.0 <3.0.0"
 
 #dependencies:
 #  path: ^1.6.0


### PR DESCRIPTION
Hi,

Thanks for creating this package, I find it very useful :)
I edited your code a little, I thought I could make this PR.

This PR:
* Adds generic types. I think they're very necessary for type inference, particularly for the `add` method.
* Hides the implementation. In particular, it makes private the following fields: `nextCycle`, `isCancelled`, `isProcessing`. Keeping them public could break the logic if they're modified. It also makes the `process` function private, I thought it would be better, what do you think?
* Adds some documentation for public functions and fields.