### PR TITLE
Feature/priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://pub.dev/packages/alfred
 
 The most simple example:
 ```dart
-import 'package:dart_queue/dart_queue.dart';
+import 'package:queue/queue.dart';
 
 main() async {
   final queue = Queue();
@@ -32,22 +32,22 @@ main() async {
 A proof of concept:
 
 ```dart
-import 'package:dart_queue/dart_queue.dart';
+import 'package:queue/queue.dart';
 
 main() async {
   //Create the queue container
   final Queue queue = Queue(delay: Duration(milliseconds: 10));
-  
+
   //Add items to the queue asyncroniously
   queue.add(()=>Future.delayed(Duration(milliseconds: 100)));
   queue.add(()=>Future.delayed(Duration(milliseconds: 10)));
-  
+
   //Get a result from the future in line with await
   final result = await queue.add(() async {
     await Future.delayed(Duration(milliseconds: 1));
     return "Future Complete";
   });
-  
+
   //100, 10, 1 will reslove in that order.
   result == "Future Complete"; //true
 }
@@ -55,10 +55,10 @@ main() async {
 
 #### Parallel processing
 This doesn't work in batches and will fire the next item as soon as as there is space in the queue
-Use [Queue(delayed: ...)] to specify a delay before firing the next item  
+Use [Queue(delayed: ...)] to specify a delay before firing the next item
 
 ```dart
-import 'package:dart_queue/dart_queue.dart';
+import 'package:queue/queue.dart';
 
 main() async {
   final queue = Queue(parallel: 2);
@@ -73,7 +73,7 @@ main() async {
 
 #### On complete
 ```dart
-import 'package:dart_queue/dart_queue.dart';
+import 'package:queue/queue.dart';
 
 main() async {
   final queue = Queue(parallel: 2);
@@ -92,7 +92,7 @@ main() async {
 You can specify a delay before the next item is fired as per the following example:
 
 ```dart
-import 'package:dart_queue/dart_queue.dart';
+import 'package:queue/queue.dart';
 
 main() async {
   final queue = Queue(delay: Duration(milliseconds: 500)); // Set the delay here
@@ -127,7 +127,7 @@ This is necessary to close the `Queue.remainingItems` controller.
 If you want to query how many items are outstanding in the queue, listen to the Queue.remainingItems stream.
 
 ```dart
-import 'package:dart_queue/dart_queue.dart';
+import 'package:queue/queue.dart';
 final queue = Queue();
 
 final remainingItemsStream = queue.remainingItems.listen((numberOfItems)=>print(numberOfItems));
@@ -144,7 +144,7 @@ queue.dispose(); // Will clean up any resources in the queue if you are done wit
 
 ## Contributing
 
-Pull requests are welcome. There is a shell script `ci_checks.sh` that will run the checks to get 
+Pull requests are welcome. There is a shell script `ci_checks.sh` that will run the checks to get
 past CI and also format the code before committing. If that all passes your PR will likely be accepted.
 
 Please write tests to cover your new feature.

--- a/test/queue_test.dart
+++ b/test/queue_test.dart
@@ -181,6 +181,28 @@ void main() {
       expect(errorQueue.activeItems.length, 0);
       expect(hitError, 101);
     });
+
+    test("it should honor priorities", () async {
+      final result = <int>[];
+      unawaited(queue.add(() async {
+        await Future.delayed(const Duration(milliseconds: 100));
+        result.add(1);
+      }));
+      unawaited(queue.add(() async {
+        await Future.delayed(const Duration(milliseconds: 100));
+        result.add(2);
+      }));
+      unawaited(queue.add(() async {
+        await Future.delayed(const Duration(milliseconds: 100));
+        result.add(3);
+      }, needsPriority: true));
+
+      await queue.onComplete;
+
+      expect(result[0], 1);
+      expect(result[1], 3);
+      expect(result[2], 2);
+    });
   });
 
   test('should cancel', () async {

--- a/test/queue_test.dart
+++ b/test/queue_test.dart
@@ -234,21 +234,21 @@ void main() {
           .catchError((err) => errors.add(err)),
       cancelQueue
           .add(() async {
-            await Future.delayed(const Duration(milliseconds: 20));
+            await Future.delayed(const Duration(milliseconds: 10));
             return "result 4";
           })
           .then((result) => results.add(result))
           .catchError((err) => errors.add(err)),
       cancelQueue
           .add(() async {
-            await Future.delayed(const Duration(milliseconds: 20));
+            await Future.delayed(const Duration(milliseconds: 10));
             return "result 5";
           })
           .then((result) => results.add(result))
           .catchError((err) => errors.add(err))
     ]));
 
-    await Future.delayed(const Duration(milliseconds: 35));
+    await Future.delayed(const Duration(milliseconds: 25));
     cancelQueue.cancel();
     await cancelQueue.onComplete;
     expect(results.length, 3);

--- a/test/queue_test.dart
+++ b/test/queue_test.dart
@@ -185,15 +185,15 @@ void main() {
     test("it should honor priorities", () async {
       final result = <int>[];
       unawaited(queue.add(() async {
-        await Future.delayed(const Duration(milliseconds: 100));
+        await Future.delayed(const Duration(milliseconds: 10));
         result.add(1);
       }));
       unawaited(queue.add(() async {
-        await Future.delayed(const Duration(milliseconds: 100));
+        await Future.delayed(const Duration(milliseconds: 10));
         result.add(2);
       }));
       unawaited(queue.add(() async {
-        await Future.delayed(const Duration(milliseconds: 100));
+        await Future.delayed(const Duration(milliseconds: 10));
         result.add(3);
       }, needsPriority: true));
 

--- a/test/queue_test.dart
+++ b/test/queue_test.dart
@@ -232,6 +232,10 @@ void main() {
     expect(results.length, 3);
     expect(errors.length, 2);
     expect(errors.first is QueueCancelledException, true);
+    try {
+      cancelQueue.add(() => Future.value(5));
+      expect("this should never", "get called because the queue got cancelled");
+    } on QueueCancelledException catch (exception) {}
   });
 
   test("timed out queue item still completes", () async {

--- a/test/queue_test.dart
+++ b/test/queue_test.dart
@@ -212,21 +212,21 @@ void main() {
           .catchError((err) => errors.add(err)),
       cancelQueue
           .add(() async {
-            await Future.delayed(const Duration(milliseconds: 10));
+            await Future.delayed(const Duration(milliseconds: 20));
             return "result 4";
           })
           .then((result) => results.add(result))
           .catchError((err) => errors.add(err)),
       cancelQueue
           .add(() async {
-            await Future.delayed(const Duration(milliseconds: 10));
+            await Future.delayed(const Duration(milliseconds: 20));
             return "result 5";
           })
           .then((result) => results.add(result))
           .catchError((err) => errors.add(err))
     ]));
 
-    await Future.delayed(const Duration(milliseconds: 25));
+    await Future.delayed(const Duration(milliseconds: 35));
     cancelQueue.cancel();
     await cancelQueue.onComplete;
     expect(results.length, 3);


### PR DESCRIPTION
We needed the option to enqueue tasks with priorities. This is a first shot at it. Let me know what you think.

* Also fixes obsolete imports in the README.

First step towards https://github.com/rknell/dart_queue/issues/3

---
And one question: Some tests were running very flaky on my machine, namely `it should handle an error correctly (also testing oncomplete)` fails from time to time with this error message:

```
00:32 +5 -1: Queue it should handle an error correctly (also testing oncomplete) [E]                                                                             
  TimeoutException after 0:00:30.000000: Test timed out after 30 seconds. See https://pub.dev/packages/test#timeouts
  dart:isolate  _RawReceivePortImpl._handleMessage
```

Any idea? I am on latest macOS 11.2.1 and this is my `flutter doctor`:

```
[✓] Flutter (Channel stable, 2.0.1, on macOS 11.2.1 20D74 darwin-x64, locale en-GB)
[✓] Android toolchain - develop for Android devices (Android SDK version 28.0.3)
[✓] Xcode - develop for iOS and macOS
[✗] Chrome - develop for the web (Cannot find Chrome executable at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome)
    ! Cannot find Chrome. Try setting CHROME_EXECUTABLE to a Chrome executable.
[✓] Android Studio (version 4.1)
[✓] VS Code (version 1.54.1)
[✓] Connected device (2 available)
```