### PR TITLE
Fixed the problem of exceeding the specified number of concurrent tasks

### DIFF
--- a/lib/src/dart_queue_base.dart
+++ b/lib/src/dart_queue_base.dart
@@ -147,7 +147,7 @@ class Queue {
   void _queueUpNext() {
     if (_nextCycle.isNotEmpty &&
         !isCancelled &&
-        activeItems.length <= parallel) {
+        activeItems.length < parallel) {
       final processId = _lastProcessId;
       activeItems.add(processId);
       final item = _nextCycle.first;


### PR DESCRIPTION
When a task is completed and there is a delay at line 159, calling _queueUpNext at line 162 may potentially result in exceeding the maximum concurrent execution limit.