### PR TITLE
Fixed the problem of when cancel Unhandled Exception: Instance of 'QueueCancelledException'

### DIFF
--- a/example/queue_example.dart
+++ b/example/queue_example.dart
@@ -7,27 +7,36 @@ Future<void> main() async {
     print(message);
   }
 
-  unawaited(queue.add(() async {
-    await asyncMessage("Message 1");
-  }).then((result) => print("Message 1 complete")));
+  unawaited(queue
+      .add(() async {
+        await asyncMessage("Message 1");
+      })
+      .then((result) => print("Message 1 complete"))
+      .catchError((e) => print("Message 1 error: $e")));
 
-  await queue.add(() async {
+  unawaited(queue.add(() async {
     await asyncMessage("Message 2");
-  });
+  }).catchError((e) => print("Message 2 error: $e")));
 
-  await Future.delayed(const Duration(milliseconds: 500));
+  // await Future.delayed(const Duration(milliseconds: 500));
 
-  print('Message 2 complete');
+  // print('Message 2 complete');
 
-  unawaited(queue.add(() async {
-    await asyncMessage("Message 3");
-    print("awaited message");
-    throw Exception("Error");
-  }).then((result) => print("Message 3 complete")));
+  queue.cancel();
+
+  unawaited(queue
+      .add(() async {
+        await asyncMessage("Message 3");
+        print("awaited message");
+        // throw Exception("Error");
+      })
+      .then((result) => print("Message 3 complete"))
+      .catchError((e) => print("Message 3 error: $e")));
 
   unawaited(queue
       .add(() async => asyncMessage("Message 4"))
-      .then((result) => print("Message 4 complete")));
+      .then((result) => print("Message 4 complete"))
+      .catchError((e) => print("Message 3 error: $e")));
 }
 
 void unawaited(Future<void> future) {}

--- a/lib/src/dart_queue_base.dart
+++ b/lib/src/dart_queue_base.dart
@@ -57,9 +57,7 @@ class Queue {
   /// Can be edited mid processing
   int parallel;
   int _lastProcessId = 0;
-  bool _isCancelled = false;
 
-  bool get isCancelled => _isCancelled;
   StreamController<int>? _remainingItemsController;
 
   Stream<int> get remainingItems {
@@ -93,7 +91,6 @@ class Queue {
       item.completer.completeError(QueueCancelledException());
     }
     _nextCycle.removeWhere((item) => item.completer.isCompleted);
-    _isCancelled = true;
   }
 
   /// Dispose of the queue
@@ -115,7 +112,6 @@ class Queue {
   ///
   /// Will throw an exception if the queue has been cancelled.
   Future<T> add<T>(Future<T> Function() closure) {
-    if (isCancelled) throw QueueCancelledException();
     final completer = Completer<T>();
     _nextCycle.add(_QueuedFuture<T>(closure, completer, timeout));
     _updateRemainingItems();
@@ -145,9 +141,7 @@ class Queue {
   }
 
   void _queueUpNext() {
-    if (_nextCycle.isNotEmpty &&
-        !isCancelled &&
-        activeItems.length <= parallel) {
+    if (_nextCycle.isNotEmpty && activeItems.length <= parallel) {
       final processId = _lastProcessId;
       activeItems.add(processId);
       final item = _nextCycle.first;


### PR DESCRIPTION
```
import 'package:queue/queue.dart';

Future<void> main() async {
  final queue = Queue(delay: const Duration(milliseconds: 100));

  Future asyncMessage(String message) async {
    print(message);
  }

  unawaited(queue
      .add(() async {
        await asyncMessage("Message 1");
      })
      .then((result) => print("Message 1 complete"))
      .catchError((e) => print("Message 1 error: $e")));

  unawaited(queue.add(() async {
    await asyncMessage("Message 2");
  }).catchError((e) => print("Message 2 error: $e")));

  queue.cancel();

  unawaited(queue
      .add(() async {
        await asyncMessage("Message 3");
        print("awaited message");
        // throw Exception("Error");
      })
      .then((result) => print("Message 3 complete"))
      .catchError((e) => print("Message 3 error: $e")));

  unawaited(queue
      .add(() async => asyncMessage("Message 4"))
      .then((result) => print("Message 4 complete"))
      .catchError((e) => print("Message 3 error: $e")));
}

void unawaited(Future<void> future) {}

```
> Error Log:

<img width="809" alt="image" src="https://user-images.githubusercontent.com/8444646/234910391-c547e2b3-0016-4883-9a5d-826fd389f1e6.png">
