### PR TITLE
Add an option to cancel the queue without throwing errors

### DIFF
--- a/lib/src/dart_queue_base.dart
+++ b/lib/src/dart_queue_base.dart
@@ -52,9 +52,12 @@ class Queue {
   /// A timeout before processing the next item in the queue
   final Duration? timeout;
 
-  /// Shoud we process this queue LIFO (last in first out)
+  /// Should we process this queue LIFO (last in first out)
   final bool lifo;
 
+  ///Should we throw an exception for items still in the Queue when .cancel() is called
+  final bool supressErrorsOnCancel;
+  
   /// The number of items to process at one time
   ///
   /// Can be edited mid processing
@@ -97,7 +100,14 @@ class Queue {
   /// Subsquent calls to [add] will throw.
   void cancel() {
     for (final item in _nextCycle) {
-      item.completer.completeError(QueueCancelledException());
+      if (supressErrorsOnCancel == false)
+        {
+          item.completer.completeError(QueueCancelledException());
+        }
+      else
+        {
+          item.completer.complete();
+        }
     }
     _nextCycle.removeWhere((item) => item.completer.isCompleted);
     _isCancelled = true;
@@ -113,7 +123,7 @@ class Queue {
     cancel();
   }
 
-  Queue({this.delay, this.parallel = 1, this.timeout, this.lifo = false});
+  Queue({this.delay, this.parallel = 1, this.timeout, this.lifo = false, this.supressErrorsOnCancel = false});
 
   /// Adds the future-returning closure to the queue.
   ///


### PR DESCRIPTION
In my use case, Id like to cancel a Queue and get rid of all the items within the queue, but without throwing the `QueueCancelledException`.  A so called 'silent' cancel.

Here I've added an option `supressErrorsOnCancel` which defaults to `false` so it doesn't do any breaking changes
But if its true then instead of doing a `.completeError` it will just do a `.complete`

This is the part I'm unsure if it's going to function as intended.  In my own use case this seems to be working just fine.  But please review if you think it should be merged in.

Essentially, I'm expecting that it will just close out the queue item with a `.complete` without actually executing the queue item.  If its not working like that then please feel free to reject this PR